### PR TITLE
Add setup experience for new users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ coverage.html
 web/node_modules/
 web/dist/
 
+# Ponko config (contains secrets)
+ponko.yaml
+
 # Ralph
 progress.txt
 /prd.json

--- a/README.md
+++ b/README.md
@@ -14,62 +14,67 @@ Ponko is a single Go binary backed by Postgres. Deploy it, connect it to Slack, 
 - **Supports per-channel configuration** — different prompts, tools, and behavior per channel
 - **Includes a management dashboard** for channel config and job monitoring
 
+## Prerequisites
+
+You'll need these before you start:
+
+- **Slack workspace** where you can create apps — [create a Slack app](https://api.slack.com/apps) and follow the [Slack setup guide](docs/slack-setup.md) to get your bot token, signing secret, and bot user ID
+- **Anthropic API key** — [console.anthropic.com](https://console.anthropic.com)
+- **Fly.io account + CLI** — [fly.io](https://fly.io), install with `curl -L https://fly.io/install.sh | sh`
+
 ## Quick Start
 
-### Prerequisites
+### Option A: Setup script (~10 min)
 
-- Go 1.25+ (or use the Docker image)
-- PostgreSQL
-- A Slack workspace where you can create apps
-- An Anthropic API key
+```bash
+./scripts/setup.sh
+```
 
-### 1. Start the database
+The script walks you through collecting credentials, provisioning Fly.io infrastructure, and deploying. It generates secrets automatically. You'll need to have your Slack app created and your Anthropic API key ready before running it.
+
+### Option B: Manual deploy
+
+```bash
+# 1. Create config from template
+cp ponko.example.yaml ponko.yaml
+# Fill in your Slack and Anthropic credentials
+
+# 2. Provision infrastructure
+fly apps create my-ponko
+fly postgres create --name my-ponko-db --region iad
+fly postgres attach my-ponko-db --app my-ponko
+
+# 3. Set secrets
+fly secrets set -a my-ponko \
+  ANTHROPIC_API_KEY="sk-ant-..." \
+  SLACK_BOT_TOKEN="xoxb-..." \
+  SLACK_SIGNING_SECRET="..." \
+  SLACK_BOT_USER_ID="U..." \
+  PONKO_API_KEY="$(openssl rand -hex 32)" \
+  COOKIE_SIGNING_KEY="$(openssl rand -hex 32)" \
+  DASHBOARD_URL="https://my-ponko.fly.dev"
+
+# 4. Update fly.toml and deploy
+sed -i '' "s/<your-app>/my-ponko/" fly.toml
+fly deploy
+```
+
+After deploying, set your Slack app's Event Subscriptions URL to `https://<your-app>.fly.dev/slack/events`, invite the bot to a channel, and @mention it.
+
+See the full [setup guide](docs/setup.md) for Docker deployment, dashboard OAuth setup, and troubleshooting.
+
+### Local Development
 
 ```bash
 make db-up
-```
-
-### 2. Set environment variables
-
-```bash
 export DATABASE_URL="postgres://agent:agent@localhost:5433/agent_dev?sslmode=disable"
 export ANTHROPIC_API_KEY="sk-ant-..."
 export SLACK_BOT_TOKEN="xoxb-..."
 export SLACK_SIGNING_SECRET="..."
-```
-
-### 3. Run
-
-```bash
 make run
 ```
 
-### 4. Deploy
-
-Ponko ships as a single binary. Deploy it anywhere that runs Go or Docker:
-
-```bash
-# Fly.io
-fly deploy
-
-# Docker
-docker build -t ponko .
-docker run -e DATABASE_URL=... -e ANTHROPIC_API_KEY=... -e SLACK_BOT_TOKEN=... ponko
-```
-
 Database migrations run automatically on startup.
-
-## Slack Bot Setup
-
-1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps)
-2. Add bot token scopes: `app_mentions:read`, `chat:write`, `reactions:write`
-3. Enable Event Subscriptions, subscribe to `app_mention`, set the request URL to `https://<your-host>/slack/events`
-4. Install the app to your workspace
-5. Copy the Bot Token (`SLACK_BOT_TOKEN`) and Signing Secret (`SLACK_SIGNING_SECRET`)
-6. Invite the bot to a channel: `/invite @YourBot`
-7. Mention it: `@YourBot what's the weather?`
-
-See the full [Slack setup guide](docs/slack-setup.md) for details on OAuth, dashboard access, and advanced configuration.
 
 ## How It Works
 
@@ -161,15 +166,27 @@ Add these environment variables:
 | `SLACK_SIGNING_SECRET` | Yes | Slack app signing secret |
 | `SLACK_BOT_USER_ID` | Yes | Bot's Slack member ID (prevents self-replies) |
 | `BOT_NAME` | No | Bot's display name for prompts and messages (default: "Ponko") |
+| `SYSTEM_PROMPT` | No | Custom system prompt to define the bot's personality and instructions |
+| `TIMEZONE` | No | IANA timezone for scheduled messages (default: "America/Los_Angeles") |
 | `PONKO_API_KEY` | No | Bearer token for API authentication |
+| `WORKER_CONCURRENCY` | No | Job worker concurrency (default: 5) |
 | `MCP_SERVER_URLS` | No | Comma-separated MCP server URLs |
 | `MCP_ACCESS_KEY` | No | Shared access key for MCP servers |
+| `GITHUB_MCP_URL` | No | GitHub MCP server URL |
+| `GITHUB_PAT` | No | GitHub personal access token (required if `GITHUB_MCP_URL` is set) |
+| `LINEAR_MCP_URL` | No | Linear MCP server URL |
+| `LINEAR_MCP_ACCESS_TOKEN` | No | Linear MCP access token |
+| `LINEAR_MCP_TOKEN_URL` | No | Linear OAuth token refresh URL |
+| `LINEAR_MCP_CLIENT_ID` | No | Linear OAuth client ID |
+| `LINEAR_MCP_CLIENT_SECRET` | No | Linear OAuth client secret |
+| `LINEAR_MCP_REFRESH_TOKEN` | No | Linear OAuth refresh token |
 | `SLACK_CLIENT_ID` | No | For dashboard OAuth |
 | `SLACK_CLIENT_SECRET` | No | For dashboard OAuth |
 | `COOKIE_SIGNING_KEY` | No | For dashboard sessions |
 | `DASHBOARD_URL` | No | Public URL for OAuth redirect |
 | `SLACK_TEAM_ID` | No | Restrict dashboard to one workspace |
-| `WORKER_CONCURRENCY` | No | Job worker concurrency (default: 5) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | OpenTelemetry collector endpoint |
+| `OTEL_EXPORTER` | No | Exporter type: "otlp" or "stdout" |
 
 ## Cost
 
@@ -201,6 +218,7 @@ MIT
 
 ## Links
 
-- [Vision](vision.md)
-- [Architecture](docs/architecture.md)
+- [Setup Guide](docs/setup.md)
 - [Slack Setup Guide](docs/slack-setup.md)
+- [Architecture](docs/architecture.md)
+- [Vision](vision.md)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -208,7 +208,7 @@ func main() {
 		Pool:       pool,
 		Claude:     claudeClient,
 		Slack:      slackClient,
-		AppBaseURL: os.Getenv("APP_BASE_URL"),
+		AppBaseURL: os.Getenv("DASHBOARD_URL"),
 	})
 	river.AddWorker(workers, &jobs.ExecuteWorker{
 		Pool:         pool,

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,158 @@
+# Setup Guide
+
+Get Ponko running in Slack in under 10 minutes.
+
+## Prerequisites
+
+- [Fly.io](https://fly.io) account + CLI (`fly` command)
+- Slack workspace with admin access
+- [Anthropic API key](https://console.anthropic.com)
+
+## Quick Start (automated)
+
+```bash
+./scripts/setup.sh
+```
+
+The setup script walks you through everything interactively. It creates your config, provisions infrastructure, and deploys.
+
+## Manual Setup
+
+### 1. Create a Slack App (~3 min)
+
+Follow the [Slack setup guide](slack-setup.md) to create your bot and collect:
+- Bot User OAuth Token (`xoxb-...`)
+- Signing Secret
+- Bot User ID (`U...`)
+
+### 2. Get an Anthropic API Key (~1 min)
+
+1. Go to [console.anthropic.com](https://console.anthropic.com)
+2. Create an API key
+3. Save it — you'll need it in step 3
+
+### 3. Create Config
+
+```bash
+cp ponko.example.yaml ponko.yaml
+```
+
+Fill in the required values:
+```yaml
+slack:
+  bot_token: "xoxb-your-token"
+  signing_secret: "your-signing-secret"
+  bot_user_id: "U12345678"
+
+ai:
+  anthropic_api_key: "sk-ant-your-key"
+```
+
+Generate secrets for API auth and cookie signing:
+```bash
+openssl rand -hex 32  # Use for deploy.api_key
+openssl rand -hex 32  # Use for deploy.cookie_signing_key
+```
+
+### 4. Deploy to Fly.io
+
+```bash
+# Create the app
+fly apps create my-ponko
+
+# Create and attach a Postgres database
+fly postgres create --name my-ponko-db --region iad
+fly postgres attach my-ponko-db --app my-ponko
+
+# Set secrets
+fly secrets set -a my-ponko \
+  ANTHROPIC_API_KEY="sk-ant-..." \
+  SLACK_BOT_TOKEN="xoxb-..." \
+  SLACK_SIGNING_SECRET="..." \
+  SLACK_BOT_USER_ID="U..." \
+  PONKO_API_KEY="$(openssl rand -hex 32)" \
+  COOKIE_SIGNING_KEY="$(openssl rand -hex 32)" \
+  DASHBOARD_URL="https://my-ponko.fly.dev"
+
+# Update fly.toml with your app name
+sed -i '' "s/<your-app>/my-ponko/" fly.toml
+
+# Deploy
+fly deploy
+```
+
+### 5. Connect Slack
+
+1. Go to your [Slack app settings](https://api.slack.com/apps) > Event Subscriptions
+2. Set the Request URL to:
+   ```
+   https://my-ponko.fly.dev/slack/events
+   ```
+3. Slack will verify the URL — your app must be running
+
+### 6. Test
+
+```
+/invite @YourBot
+@YourBot hello
+```
+
+The bot should reply in a thread.
+
+## Docker (Local/Self-Hosted)
+
+For local development or self-hosted Docker deployments:
+
+```bash
+# Create config
+cp ponko.example.yaml ponko.yaml
+# Edit ponko.yaml with your values, set deploy.platform to "docker"
+
+# Generate .env from config
+./scripts/setup.sh deploy
+
+# Start services
+docker compose up -d
+```
+
+Your bot will be running at `http://localhost:8080`. Use [ngrok](https://ngrok.com) or a similar tunnel to expose it for Slack event subscriptions.
+
+## Dashboard Setup (Optional)
+
+The management dashboard uses Slack OAuth for authentication. Add these to your config:
+
+```yaml
+dashboard:
+  slack_client_id: "your-client-id"
+  slack_client_secret: "your-client-secret"
+  slack_team_id: "T12345678"
+```
+
+See [Slack setup guide — Dashboard Setup](slack-setup.md#dashboard-setup-optional) for how to get these values.
+
+## Re-deploy / Validate
+
+```bash
+# Re-deploy from existing ponko.yaml
+./scripts/setup.sh deploy
+
+# Validate config and check health
+./scripts/setup.sh validate
+```
+
+## Troubleshooting
+
+**Slack verification fails**
+Your app must be running and accessible before Slack can verify the Event Subscriptions URL. Deploy first, then set the URL.
+
+**Bot doesn't reply**
+Check that `SLACK_BOT_USER_ID` is correct. This prevents the bot from responding to its own messages — if it's wrong, the bot ignores everything.
+
+**Dashboard login fails**
+Verify the OAuth redirect URL in your Slack app settings matches `DASHBOARD_URL` + `/api/auth/slack/callback`.
+
+**Health check fails**
+```bash
+curl https://your-app.fly.dev/health
+```
+Should return `{"status":"ok"}`. If not, check `fly logs --app your-app --no-tail`.

--- a/docs/slack-setup.md
+++ b/docs/slack-setup.md
@@ -1,6 +1,6 @@
 # Slack Setup Guide
 
-Complete guide to creating and configuring a Slack bot for Ponko.
+Complete guide to creating and configuring a Slack bot for Ponko. Part of the [setup guide](setup.md).
 
 ## Step 1: Create a Slack App
 

--- a/ponko.example.yaml
+++ b/ponko.example.yaml
@@ -1,0 +1,59 @@
+# ponko.yaml — Ponko configuration
+# Copy this file: cp ponko.example.yaml ponko.yaml
+# Then fill in your values, or run: ./scripts/setup.sh
+
+# ── Bot ───────────────────────────────────────────────
+bot:
+  name: "Ponko"                    # Display name in prompts and Slack messages
+  timezone: "America/Los_Angeles"  # IANA timezone for scheduled messages
+  system_prompt: ""                # Optional: override default personality
+
+# ── Slack (required) ──────────────────────────────────
+slack:
+  bot_token: ""                    # Bot User OAuth Token (xoxb-...)
+  signing_secret: ""               # App Signing Secret
+  bot_user_id: ""                  # Bot's member ID (U...)
+
+# ── AI (required) ────────────────────────────────────
+ai:
+  anthropic_api_key: ""            # From console.anthropic.com
+
+# ── Deployment ────────────────────────────────────────
+deploy:
+  platform: "fly"                  # "fly" or "docker"
+  app_name: ""                     # Fly.io app name (generated if blank)
+  region: "iad"                    # Fly.io region
+  url: ""                          # Public URL (e.g., https://your-app.fly.dev)
+  api_key: ""                      # Bearer token for API auth (generated if blank)
+  cookie_signing_key: ""           # Session signing (generated if blank)
+  worker_concurrency: 10
+
+# ── Dashboard OAuth (optional) ────────────────────────
+dashboard:
+  slack_client_id: ""
+  slack_client_secret: ""
+  slack_team_id: ""
+
+# ── MCP Tools (optional) ─────────────────────────────
+mcp:
+  server_urls: []                  # Comma-separated MCP server URLs
+  access_key: ""                   # Shared access key for MCP servers
+
+# ── GitHub MCP (optional) ────────────────────────────
+github:
+  mcp_url: ""                      # GitHub MCP server URL
+  pat: ""                          # GitHub personal access token
+
+# ── Linear MCP (optional) ────────────────────────────
+linear:
+  mcp_url: ""                      # Linear MCP server URL
+  access_token: ""                 # Linear MCP access token
+  token_url: ""                    # OAuth token refresh URL
+  client_id: ""                    # OAuth client ID
+  client_secret: ""                # OAuth client secret
+  refresh_token: ""                # OAuth refresh token
+
+# ── Observability (optional) ─────────────────────────
+observability:
+  otel_endpoint: ""                # OpenTelemetry collector endpoint
+  otel_exporter: ""                # "otlp" or "stdout"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,642 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ponko Setup Script
+# Usage:
+#   ./scripts/setup.sh           Interactive first-run setup
+#   ./scripts/setup.sh deploy    Re-deploy from existing ponko.yaml
+#   ./scripts/setup.sh validate  Check config + health
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG_FILE="$PROJECT_DIR/ponko.yaml"
+EXAMPLE_FILE="$PROJECT_DIR/ponko.example.yaml"
+
+# ── Helpers ───────────────────────────────────────────
+
+info()  { printf "\033[1;34m▸\033[0m %s\n" "$1"; }
+ok()    { printf "\033[1;32m✓\033[0m %s\n" "$1"; }
+warn()  { printf "\033[1;33m⚠\033[0m %s\n" "$1"; }
+err()   { printf "\033[1;31m✗\033[0m %s\n" "$1" >&2; }
+die()   { err "$1"; exit 1; }
+
+# Read a value from ponko.yaml (flat YAML only — key: value or key: "value")
+yaml_get() {
+    local key="$1"
+    grep -E "^[[:space:]]*${key}:" "$CONFIG_FILE" 2>/dev/null \
+        | head -1 \
+        | sed 's/^[^:]*:[[:space:]]*//' \
+        | sed 's/^"//' \
+        | sed 's/"$//' \
+        | sed "s/^'//" \
+        | sed "s/'$//"
+}
+
+# Write a value to ponko.yaml
+yaml_set() {
+    local key="$1"
+    local value="$2"
+    if grep -qE "^[[:space:]]*${key}:" "$CONFIG_FILE" 2>/dev/null; then
+        sed -i '' "s|^\([[:space:]]*${key}:\).*|\1 \"${value}\"|" "$CONFIG_FILE"
+    fi
+}
+
+# Prompt for a value with optional default
+prompt_value() {
+    local label="$1"
+    local default="${2:-}"
+    local value
+
+    if [ -n "$default" ]; then
+        printf "\033[1m%s\033[0m [%s]: " "$label" "$default"
+    else
+        printf "\033[1m%s\033[0m: " "$label"
+    fi
+    read -r value
+    if [ -z "$value" ] && [ -n "$default" ]; then
+        value="$default"
+    fi
+    echo "$value"
+}
+
+# Prompt yes/no
+prompt_yn() {
+    local label="$1"
+    local default="${2:-n}"
+    local hint="y/N"
+    [ "$default" = "y" ] && hint="Y/n"
+
+    printf "\033[1m%s\033[0m [%s]: " "$label" "$hint"
+    read -r answer
+    answer="${answer:-$default}"
+    [[ "$answer" =~ ^[Yy] ]]
+}
+
+# ── Prerequisites ─────────────────────────────────────
+
+check_prerequisites() {
+    local missing=0
+
+    if command -v fly >/dev/null 2>&1; then
+        ok "fly CLI found"
+    else
+        err "fly CLI not found"
+        info "Install: curl -L https://fly.io/install.sh | sh"
+        missing=1
+    fi
+
+    if command -v openssl >/dev/null 2>&1; then
+        ok "openssl found"
+    else
+        err "openssl not found (needed for secret generation)"
+        missing=1
+    fi
+
+    if [ $missing -ne 0 ]; then
+        die "Install missing prerequisites and re-run"
+    fi
+}
+
+check_fly_auth() {
+    if fly auth whoami >/dev/null 2>&1; then
+        ok "Logged in to Fly.io as $(fly auth whoami 2>/dev/null)"
+    else
+        info "Not logged in to Fly.io"
+        fly auth login
+    fi
+}
+
+# ── Interactive Setup ─────────────────────────────────
+
+interactive_setup() {
+    echo ""
+    echo "╔══════════════════════════════════════╗"
+    echo "║         Ponko Setup Wizard           ║"
+    echo "╚══════════════════════════════════════╝"
+    echo ""
+
+    check_prerequisites
+
+    # Platform selection
+    echo ""
+    info "Choose deployment platform:"
+    echo "  1) Fly.io (recommended)"
+    echo "  2) Docker (local/self-hosted)"
+    local platform_choice
+    platform_choice=$(prompt_value "Platform" "1")
+    local platform="fly"
+    [ "$platform_choice" = "2" ] && platform="docker"
+
+    if [ "$platform" = "fly" ]; then
+        check_fly_auth
+    fi
+
+    # Copy example config
+    if [ ! -f "$CONFIG_FILE" ]; then
+        cp "$EXAMPLE_FILE" "$CONFIG_FILE"
+        ok "Created ponko.yaml from template"
+    else
+        warn "ponko.yaml already exists — updating values in place"
+    fi
+
+    yaml_set "platform" "$platform"
+
+    # Slack setup
+    echo ""
+    info "Step 1: Slack App"
+    echo "  You need a Slack app with bot token scopes."
+    echo "  See: docs/slack-setup.md"
+    echo ""
+    if prompt_yn "Open Slack app creation page in browser?"; then
+        open "https://api.slack.com/apps" 2>/dev/null || true
+    fi
+
+    echo ""
+    local bot_token
+    bot_token=$(prompt_value "Slack Bot Token (xoxb-...)")
+    [ -z "$bot_token" ] && die "Bot token is required"
+    yaml_set "bot_token" "$bot_token"
+
+    local signing_secret
+    signing_secret=$(prompt_value "Slack Signing Secret")
+    [ -z "$signing_secret" ] && die "Signing secret is required"
+    yaml_set "signing_secret" "$signing_secret"
+
+    local bot_user_id
+    bot_user_id=$(prompt_value "Slack Bot User ID (U...)")
+    [ -z "$bot_user_id" ] && die "Bot user ID is required"
+    yaml_set "bot_user_id" "$bot_user_id"
+
+    # Anthropic
+    echo ""
+    info "Step 2: AI"
+    local anthropic_key
+    anthropic_key=$(prompt_value "Anthropic API Key (sk-ant-...)")
+    [ -z "$anthropic_key" ] && die "Anthropic API key is required"
+    yaml_set "anthropic_api_key" "$anthropic_key"
+
+    # Bot config
+    echo ""
+    info "Step 3: Bot settings"
+    local bot_name
+    bot_name=$(prompt_value "Bot name" "Ponko")
+    yaml_set "name" "$bot_name"
+
+    local timezone
+    timezone=$(prompt_value "Timezone" "America/Los_Angeles")
+    yaml_set "timezone" "$timezone"
+
+    local system_prompt
+    system_prompt=$(prompt_value "System prompt (blank for default)" "")
+    if [ -n "$system_prompt" ]; then
+        yaml_set "system_prompt" "$system_prompt"
+    fi
+
+    # Auto-generate secrets
+    local api_key
+    api_key=$(openssl rand -hex 32)
+    yaml_set "api_key" "$api_key"
+    ok "Generated API key"
+
+    local cookie_key
+    cookie_key=$(openssl rand -hex 32)
+    yaml_set "cookie_signing_key" "$cookie_key"
+    ok "Generated cookie signing key"
+
+    # Optional: Dashboard OAuth
+    echo ""
+    if prompt_yn "Set up dashboard OAuth? (allows Slack login to admin UI)"; then
+        local client_id
+        client_id=$(prompt_value "Slack Client ID")
+        yaml_set "slack_client_id" "$client_id"
+
+        local client_secret
+        client_secret=$(prompt_value "Slack Client Secret")
+        yaml_set "slack_client_secret" "$client_secret"
+
+        local team_id
+        team_id=$(prompt_value "Slack Team ID (T...)")
+        yaml_set "slack_team_id" "$team_id"
+    fi
+
+    # Optional: MCP
+    echo ""
+    if prompt_yn "Configure MCP tool servers?"; then
+        local mcp_urls
+        mcp_urls=$(prompt_value "MCP Server URLs (comma-separated)")
+        yaml_set "server_urls" "$mcp_urls"
+
+        local mcp_key
+        mcp_key=$(prompt_value "MCP Access Key (blank if none)" "")
+        if [ -n "$mcp_key" ]; then
+            yaml_set "access_key" "$mcp_key"
+        fi
+    fi
+
+    # Optional: GitHub MCP
+    echo ""
+    if prompt_yn "Configure GitHub MCP integration?"; then
+        local github_url
+        github_url=$(prompt_value "GitHub MCP server URL")
+        yaml_set "mcp_url" "$github_url"
+
+        local github_pat
+        github_pat=$(prompt_value "GitHub Personal Access Token")
+        yaml_set "pat" "$github_pat"
+    fi
+
+    # Optional: Linear MCP
+    echo ""
+    if prompt_yn "Configure Linear MCP integration?"; then
+        local linear_url
+        linear_url=$(prompt_value "Linear MCP server URL")
+        # Use a unique grep match — linear section has its own mcp_url
+        sed -i '' "/^# ── Linear/,/^# ──/{s|^\([[:space:]]*mcp_url:\).*|\1 \"${linear_url}\"|;}" "$CONFIG_FILE"
+
+        local linear_token
+        linear_token=$(prompt_value "Linear access token")
+        yaml_set "access_token" "$linear_token"
+
+        local linear_token_url
+        linear_token_url=$(prompt_value "Linear OAuth token URL")
+        yaml_set "token_url" "$linear_token_url"
+
+        local linear_client_id
+        linear_client_id=$(prompt_value "Linear OAuth client ID")
+        yaml_set "client_id" "$linear_client_id"
+
+        local linear_client_secret
+        linear_client_secret=$(prompt_value "Linear OAuth client secret")
+        yaml_set "client_secret" "$linear_client_secret"
+
+        local linear_refresh
+        linear_refresh=$(prompt_value "Linear OAuth refresh token")
+        yaml_set "refresh_token" "$linear_refresh"
+    fi
+
+    ok "Config saved to ponko.yaml"
+
+    # Deploy
+    echo ""
+    if [ "$platform" = "fly" ]; then
+        deploy_fly
+    else
+        deploy_docker
+    fi
+}
+
+# ── Fly.io Deploy ─────────────────────────────────────
+
+deploy_fly() {
+    info "Deploying to Fly.io..."
+
+    local app_name
+    app_name=$(yaml_get "app_name")
+    if [ -z "$app_name" ]; then
+        local random_suffix
+        random_suffix=$(openssl rand -hex 2)
+        app_name=$(prompt_value "App name" "ponko-${random_suffix}")
+        yaml_set "app_name" "$app_name"
+    fi
+
+    local region
+    region=$(yaml_get "region")
+    region="${region:-iad}"
+
+    local dashboard_url
+    dashboard_url=$(yaml_get "url")
+    if [ -z "$dashboard_url" ]; then
+        dashboard_url="https://${app_name}.fly.dev"
+        yaml_set "url" "$dashboard_url"
+    fi
+
+    # Create app
+    info "Creating Fly.io app: $app_name"
+    if fly apps list 2>/dev/null | grep -q "$app_name"; then
+        warn "App $app_name already exists, skipping creation"
+    else
+        fly apps create "$app_name" --machines
+        ok "App created"
+    fi
+
+    # Create and attach Postgres
+    local db_name="${app_name}-db"
+    info "Creating Postgres: $db_name"
+    if fly apps list 2>/dev/null | grep -q "$db_name"; then
+        warn "Database $db_name already exists, skipping creation"
+    else
+        fly postgres create --name "$db_name" --region "$region" --initial-cluster-size 1 --vm-size shared-cpu-1x --volume-size 1
+        ok "Postgres created"
+    fi
+
+    info "Attaching database..."
+    fly postgres attach "$db_name" --app "$app_name" 2>/dev/null || warn "Database may already be attached"
+
+    # Set secrets
+    info "Setting secrets..."
+    local bot_token signing_secret bot_user_id anthropic_key api_key cookie_key
+    local bot_name timezone worker_concurrency system_prompt
+    bot_token=$(yaml_get "bot_token")
+    signing_secret=$(yaml_get "signing_secret")
+    bot_user_id=$(yaml_get "bot_user_id")
+    anthropic_key=$(yaml_get "anthropic_api_key")
+    api_key=$(yaml_get "api_key")
+    cookie_key=$(yaml_get "cookie_signing_key")
+    bot_name=$(yaml_get "name")
+    timezone=$(yaml_get "timezone")
+    worker_concurrency=$(yaml_get "worker_concurrency")
+    system_prompt=$(yaml_get "system_prompt")
+
+    local secrets_cmd="fly secrets set -a $app_name"
+    secrets_cmd+=" ANTHROPIC_API_KEY=$anthropic_key"
+    secrets_cmd+=" SLACK_BOT_TOKEN=$bot_token"
+    secrets_cmd+=" SLACK_SIGNING_SECRET=$signing_secret"
+    secrets_cmd+=" SLACK_BOT_USER_ID=$bot_user_id"
+    secrets_cmd+=" PONKO_API_KEY=$api_key"
+    secrets_cmd+=" COOKIE_SIGNING_KEY=$cookie_key"
+    secrets_cmd+=" DASHBOARD_URL=$dashboard_url"
+    [ -n "$bot_name" ] && [ "$bot_name" != "Ponko" ] && secrets_cmd+=" BOT_NAME=$bot_name"
+    [ -n "$timezone" ] && [ "$timezone" != "America/Los_Angeles" ] && secrets_cmd+=" TIMEZONE=$timezone"
+    [ -n "$worker_concurrency" ] && secrets_cmd+=" WORKER_CONCURRENCY=$worker_concurrency"
+    [ -n "$system_prompt" ] && secrets_cmd+=" SYSTEM_PROMPT=$system_prompt"
+
+    # Optional: Dashboard OAuth
+    local client_id client_secret team_id
+    client_id=$(yaml_get "slack_client_id")
+    client_secret=$(yaml_get "slack_client_secret")
+    team_id=$(yaml_get "slack_team_id")
+    [ -n "$client_id" ] && secrets_cmd+=" SLACK_CLIENT_ID=$client_id"
+    [ -n "$client_secret" ] && secrets_cmd+=" SLACK_CLIENT_SECRET=$client_secret"
+    [ -n "$team_id" ] && secrets_cmd+=" SLACK_TEAM_ID=$team_id"
+
+    # Optional: MCP
+    local mcp_urls mcp_key
+    mcp_urls=$(yaml_get "server_urls")
+    mcp_key=$(yaml_get "access_key")
+    [ -n "$mcp_urls" ] && [ "$mcp_urls" != "[]" ] && secrets_cmd+=" MCP_SERVER_URLS=$mcp_urls"
+    [ -n "$mcp_key" ] && secrets_cmd+=" MCP_ACCESS_KEY=$mcp_key"
+
+    # Optional: GitHub MCP
+    local github_url github_pat
+    github_url=$(yaml_get "mcp_url")
+    github_pat=$(yaml_get "pat")
+    [ -n "$github_url" ] && secrets_cmd+=" GITHUB_MCP_URL=$github_url"
+    [ -n "$github_pat" ] && secrets_cmd+=" GITHUB_PAT=$github_pat"
+
+    # Optional: Linear MCP
+    local linear_url linear_token linear_token_url linear_client_id linear_client_secret linear_refresh
+    linear_url=$(yaml_get "mcp_url")
+    linear_token=$(yaml_get "access_token")
+    linear_token_url=$(yaml_get "token_url")
+    linear_client_id=$(yaml_get "client_id")
+    linear_client_secret=$(yaml_get "client_secret")
+    linear_refresh=$(yaml_get "refresh_token")
+    [ -n "$linear_url" ] && secrets_cmd+=" LINEAR_MCP_URL=$linear_url"
+    [ -n "$linear_token" ] && secrets_cmd+=" LINEAR_MCP_ACCESS_TOKEN=$linear_token"
+    [ -n "$linear_token_url" ] && secrets_cmd+=" LINEAR_MCP_TOKEN_URL=$linear_token_url"
+    [ -n "$linear_client_id" ] && secrets_cmd+=" LINEAR_MCP_CLIENT_ID=$linear_client_id"
+    [ -n "$linear_client_secret" ] && secrets_cmd+=" LINEAR_MCP_CLIENT_SECRET=$linear_client_secret"
+    [ -n "$linear_refresh" ] && secrets_cmd+=" LINEAR_MCP_REFRESH_TOKEN=$linear_refresh"
+
+    # Optional: Observability
+    local otel_endpoint otel_exporter
+    otel_endpoint=$(yaml_get "otel_endpoint")
+    otel_exporter=$(yaml_get "otel_exporter")
+    [ -n "$otel_endpoint" ] && secrets_cmd+=" OTEL_EXPORTER_OTLP_ENDPOINT=$otel_endpoint"
+    [ -n "$otel_exporter" ] && secrets_cmd+=" OTEL_EXPORTER=$otel_exporter"
+
+    eval "$secrets_cmd"
+    ok "Secrets set"
+
+    # Update fly.toml
+    if grep -q "<your-app>" "$PROJECT_DIR/fly.toml"; then
+        sed -i '' "s/<your-app>/$app_name/" "$PROJECT_DIR/fly.toml"
+        ok "Updated fly.toml with app name"
+    fi
+
+    # Deploy
+    info "Deploying..."
+    (cd "$PROJECT_DIR" && fly deploy)
+    ok "Deployed!"
+
+    # Wait for health
+    echo ""
+    info "Waiting for health check..."
+    local attempts=0
+    while [ $attempts -lt 30 ]; do
+        if curl -sf "${dashboard_url}/health" >/dev/null 2>&1; then
+            ok "Health check passed!"
+            break
+        fi
+        sleep 2
+        attempts=$((attempts + 1))
+    done
+    if [ $attempts -ge 30 ]; then
+        warn "Health check timed out — the app may still be starting"
+        info "Check manually: curl ${dashboard_url}/health"
+    fi
+
+    # Success
+    echo ""
+    echo "╔══════════════════════════════════════╗"
+    echo "║          Setup Complete!             ║"
+    echo "╚══════════════════════════════════════╝"
+    echo ""
+    info "Next steps:"
+    echo "  1. Set your Slack Event Subscriptions URL to:"
+    echo "     ${dashboard_url}/slack/events"
+    echo ""
+    echo "  2. Invite the bot to a channel:"
+    echo "     /invite @${bot_name:-Ponko}"
+    echo ""
+    echo "  3. Say hello:"
+    echo "     @${bot_name:-Ponko} hello"
+    echo ""
+    if [ -n "$client_id" ]; then
+        echo "  4. Dashboard: ${dashboard_url}"
+        echo "     Set OAuth redirect URL to: ${dashboard_url}/api/auth/slack/callback"
+        echo ""
+    fi
+}
+
+# ── Docker Deploy ─────────────────────────────────────
+
+deploy_docker() {
+    info "Generating .env for Docker..."
+
+    local env_file="$PROJECT_DIR/.env"
+    local bot_token signing_secret bot_user_id anthropic_key api_key cookie_key
+    local bot_name timezone worker_concurrency dashboard_url system_prompt
+    bot_token=$(yaml_get "bot_token")
+    signing_secret=$(yaml_get "signing_secret")
+    bot_user_id=$(yaml_get "bot_user_id")
+    anthropic_key=$(yaml_get "anthropic_api_key")
+    api_key=$(yaml_get "api_key")
+    cookie_key=$(yaml_get "cookie_signing_key")
+    bot_name=$(yaml_get "name")
+    timezone=$(yaml_get "timezone")
+    worker_concurrency=$(yaml_get "worker_concurrency")
+    dashboard_url=$(yaml_get "url")
+    system_prompt=$(yaml_get "system_prompt")
+
+    cat > "$env_file" <<EOF
+DATABASE_URL=postgres://agent:agent@db:5432/agent?sslmode=disable
+ANTHROPIC_API_KEY=${anthropic_key}
+SLACK_BOT_TOKEN=${bot_token}
+SLACK_SIGNING_SECRET=${signing_secret}
+SLACK_BOT_USER_ID=${bot_user_id}
+PONKO_API_KEY=${api_key}
+COOKIE_SIGNING_KEY=${cookie_key}
+BOT_NAME=${bot_name:-Ponko}
+TIMEZONE=${timezone:-America/Los_Angeles}
+WORKER_CONCURRENCY=${worker_concurrency:-10}
+EOF
+
+    [ -n "$system_prompt" ] && echo "SYSTEM_PROMPT=${system_prompt}" >> "$env_file"
+    [ -n "$dashboard_url" ] && echo "DASHBOARD_URL=${dashboard_url}" >> "$env_file"
+
+    # Dashboard OAuth
+    local client_id client_secret team_id
+    client_id=$(yaml_get "slack_client_id")
+    client_secret=$(yaml_get "slack_client_secret")
+    team_id=$(yaml_get "slack_team_id")
+    [ -n "$client_id" ] && echo "SLACK_CLIENT_ID=${client_id}" >> "$env_file"
+    [ -n "$client_secret" ] && echo "SLACK_CLIENT_SECRET=${client_secret}" >> "$env_file"
+    [ -n "$team_id" ] && echo "SLACK_TEAM_ID=${team_id}" >> "$env_file"
+
+    # MCP
+    local mcp_urls mcp_key
+    mcp_urls=$(yaml_get "server_urls")
+    mcp_key=$(yaml_get "access_key")
+    [ -n "$mcp_urls" ] && [ "$mcp_urls" != "[]" ] && echo "MCP_SERVER_URLS=${mcp_urls}" >> "$env_file"
+    [ -n "$mcp_key" ] && echo "MCP_ACCESS_KEY=${mcp_key}" >> "$env_file"
+
+    # GitHub MCP
+    local github_url github_pat
+    github_url=$(yaml_get "mcp_url")
+    github_pat=$(yaml_get "pat")
+    [ -n "$github_url" ] && echo "GITHUB_MCP_URL=${github_url}" >> "$env_file"
+    [ -n "$github_pat" ] && echo "GITHUB_PAT=${github_pat}" >> "$env_file"
+
+    # Linear MCP
+    local linear_token linear_token_url linear_client_id linear_client_secret linear_refresh
+    linear_token=$(yaml_get "access_token")
+    linear_token_url=$(yaml_get "token_url")
+    linear_client_id=$(yaml_get "client_id")
+    linear_client_secret=$(yaml_get "client_secret")
+    linear_refresh=$(yaml_get "refresh_token")
+    # linear mcp_url conflicts with github mcp_url in yaml_get — read from Linear section
+    local linear_url
+    linear_url=$(sed -n '/^# ── Linear/,/^# ──/{/mcp_url:/p;}' "$CONFIG_FILE" 2>/dev/null | sed 's/^[^:]*:[[:space:]]*//' | sed 's/^"//' | sed 's/"$//')
+    [ -n "$linear_url" ] && echo "LINEAR_MCP_URL=${linear_url}" >> "$env_file"
+    [ -n "$linear_token" ] && echo "LINEAR_MCP_ACCESS_TOKEN=${linear_token}" >> "$env_file"
+    [ -n "$linear_token_url" ] && echo "LINEAR_MCP_TOKEN_URL=${linear_token_url}" >> "$env_file"
+    [ -n "$linear_client_id" ] && echo "LINEAR_MCP_CLIENT_ID=${linear_client_id}" >> "$env_file"
+    [ -n "$linear_client_secret" ] && echo "LINEAR_MCP_CLIENT_SECRET=${linear_client_secret}" >> "$env_file"
+    [ -n "$linear_refresh" ] && echo "LINEAR_MCP_REFRESH_TOKEN=${linear_refresh}" >> "$env_file"
+
+    # Observability
+    local otel_endpoint otel_exporter
+    otel_endpoint=$(yaml_get "otel_endpoint")
+    otel_exporter=$(yaml_get "otel_exporter")
+    [ -n "$otel_endpoint" ] && echo "OTEL_EXPORTER_OTLP_ENDPOINT=${otel_endpoint}" >> "$env_file"
+    [ -n "$otel_exporter" ] && echo "OTEL_EXPORTER=${otel_exporter}" >> "$env_file"
+
+    ok "Generated .env"
+
+    echo ""
+    info "To start:"
+    echo "  docker compose up -d"
+    echo ""
+    info "Bot will run at http://localhost:8080"
+    info "Use ngrok or similar to expose for Slack events"
+}
+
+# ── Deploy Mode ───────────────────────────────────────
+
+deploy_mode() {
+    [ ! -f "$CONFIG_FILE" ] && die "ponko.yaml not found. Run ./scripts/setup.sh first"
+
+    local platform
+    platform=$(yaml_get "platform")
+
+    case "$platform" in
+        fly)
+            check_fly_auth
+            deploy_fly
+            ;;
+        docker)
+            deploy_docker
+            ;;
+        *)
+            die "Unknown platform: $platform. Set deploy.platform to 'fly' or 'docker' in ponko.yaml"
+            ;;
+    esac
+}
+
+# ── Validate Mode ─────────────────────────────────────
+
+validate_mode() {
+    echo ""
+    info "Validating Ponko configuration..."
+    echo ""
+
+    local errors=0
+
+    # Check config exists
+    if [ ! -f "$CONFIG_FILE" ]; then
+        err "ponko.yaml not found"
+        die "Run ./scripts/setup.sh to create it"
+    fi
+    ok "ponko.yaml exists"
+
+    # Check required values
+    local required_keys="bot_token signing_secret bot_user_id anthropic_api_key"
+    for key in $required_keys; do
+        local val
+        val=$(yaml_get "$key")
+        if [ -z "$val" ]; then
+            err "Missing required value: $key"
+            errors=$((errors + 1))
+        else
+            ok "$key is set"
+        fi
+    done
+
+    # Check health endpoint
+    local url
+    url=$(yaml_get "url")
+    if [ -n "$url" ]; then
+        info "Checking health at $url..."
+        if curl -sf "${url}/health" >/dev/null 2>&1; then
+            ok "Health check passed"
+        else
+            err "Health check failed: ${url}/health"
+            errors=$((errors + 1))
+        fi
+    else
+        warn "No deploy URL set — skipping health check"
+    fi
+
+    echo ""
+    if [ $errors -eq 0 ]; then
+        ok "All checks passed!"
+    else
+        err "$errors check(s) failed"
+        exit 1
+    fi
+}
+
+# ── Main ──────────────────────────────────────────────
+
+case "${1:-}" in
+    deploy)
+        deploy_mode
+        ;;
+    validate)
+        validate_mode
+        ;;
+    *)
+        interactive_setup
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Add `ponko.example.yaml` — annotated config template covering all env vars (bot, Slack, AI, deploy, dashboard OAuth, MCP, GitHub MCP, Linear MCP, observability)
- Add `scripts/setup.sh` — interactive bash setup script with three modes: first-run wizard, `deploy` (re-deploy from existing config), `validate` (check config + health). Supports both Fly.io and Docker paths.
- Add `docs/setup.md` — step-by-step manual guide with troubleshooting section
- Consolidate `APP_BASE_URL` into `DASHBOARD_URL` in `cmd/server/main.go` (PlanWorker now reads same env var as dashboard auth)
- Update README with Prerequisites section, dual quick start paths (script vs manual), and complete env var table (adds `SYSTEM_PROMPT`, `TIMEZONE`, GitHub MCP, Linear MCP, OTEL vars)
- Add cross-link from `docs/slack-setup.md` to the new setup guide
- Add `ponko.yaml` to `.gitignore` (contains secrets)

## Test plan

- [x] `make build` passes
- [x] `make test-unit` passes
- [ ] `bash -n scripts/setup.sh` syntax check passes
- [ ] Run `./scripts/setup.sh validate` with no config — confirms it errors with guidance
- [ ] Run full `./scripts/setup.sh` on fresh Fly.io with real Slack credentials
- [ ] Verify `ponko.yaml` is not tracked by git after clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)