### PR TITLE
With no MCPs installed, return empty array from /api/tools

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -284,11 +284,9 @@ func main() {
 		slog.Warn("PONKO_API_KEY not set, workflow endpoints are unauthenticated")
 	}
 
-	var toolNames []string
-	if mcpMultiClient != nil {
-		for _, t := range mcpMultiClient.Tools() {
-			toolNames = append(toolNames, t.Name)
-		}
+	toolNames := make([]string, 0, len(allTools))
+	for _, t := range allTools {
+		toolNames = append(toolNames, t.Name)
 	}
 
 	cookieSigningKey := os.Getenv("COOKIE_SIGNING_KEY")


### PR DESCRIPTION
Go slice serializes to JSON `null`, causing the frontend Tools page to crash with "Failed to load tools." Derive toolNames from `allTools` so built-in schedule tools always appear and the array is never `null`.

#8 

Co-authored by Claude