### PR TITLE
refactor: cmd/cli countActiveRiverTasks uses river.JobList (#30)

### DIFF
--- a/cmd/cli/run.go
+++ b/cmd/cli/run.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riversqlite"
+	"github.com/riverqueue/river/rivertype"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -119,7 +120,7 @@ func runOtto(cmd *cobra.Command, _ []string) error {
 		}
 	}()
 
-	if err := doIntake(ctx, cfg, intaker, router, client, db, bus); err != nil {
+	if err := doIntake(ctx, cfg, intaker, router, client, bus); err != nil {
 		return fmt.Errorf("intake: %w", err)
 	}
 	if err := sqlite.DrainRiverQueue(ctx, db); err != nil {
@@ -151,10 +152,9 @@ func doIntake(
 	intaker *intake.Intake,
 	router *routing.Router,
 	client *river.Client[*sql.Tx],
-	db *sql.DB,
 	bus event.Bus,
 ) error {
-	active, err := countActiveRiverTasks(ctx, db)
+	active, err := countActiveRiverTasks(ctx, client)
 	if err != nil {
 		return err
 	}
@@ -204,18 +204,22 @@ func doIntake(
 	return nil
 }
 
-func countActiveRiverTasks(ctx context.Context, db *sql.DB) (int, error) {
-	var count int
-	err := db.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM river_job
-		WHERE kind IN ('task_phase', 'approval_poller')
-		  AND state IN ('available', 'running', 'pending', 'retryable', 'scheduled')
-	`).Scan(&count)
+func countActiveRiverTasks(ctx context.Context, client *river.Client[*sql.Tx]) (int, error) {
+	params := river.NewJobListParams().
+		Kinds("task_phase", "approval_poller").
+		States(
+			rivertype.JobStateAvailable,
+			rivertype.JobStateRunning,
+			rivertype.JobStatePending,
+			rivertype.JobStateRetryable,
+			rivertype.JobStateScheduled,
+		).
+		First(10000)
+	result, err := client.JobList(ctx, params)
 	if err != nil {
-		return 0, fmt.Errorf("count active river tasks: %w", err)
+		return 0, fmt.Errorf("list active river tasks: %w", err)
 	}
-	return count, nil
+	return len(result.Jobs), nil
 }
 
 func taskPhaseArgs(issue *task.Task) worker.TaskPhaseArgs {


### PR DESCRIPTION
Drops the raw `river_job` SQL query in `cmd/cli/run.go` in favor of the River client's `JobList` API. Same kind (`task_phase`, `approval_poller`) and state (`available`, `running`, `pending`, `retryable`, `scheduled`) filters, same return semantics.

Removes the now-unused `db *sql.DB` parameter from `doIntake`'s signature.

Closes #30.

## Implementation note
River's `JobList` has no count-only variant, so the function pages with `First(10000)` and counts the returned slice. That ceiling is well above any realistic `MaxActiveTasks` value for a local orchestrator (typically single digits). If we ever hit the cap we have bigger problems than counting precision.

## Test plan
- [x] \`go build ./cmd/cli\` succeeds
- [x] \`go vet ./cmd/cli/\` clean
- [x] Local pre-push \`make ci\` passes
- [ ] CI green