### PR TITLE
fix: Dockerfile builds cmd/slack (was cmd/server, broke after #28 merge)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 
 COPY . .
 COPY --from=web-builder /app/web/dist web/dist
-RUN CGO_ENABLED=0 go build -o server ./cmd/server
+RUN CGO_ENABLED=0 go build -o server ./cmd/slack
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
## What
PR #28 merged ponko-runtime into ponko and renamed entrypoints from `cmd/server` to four binaries (`cmd/slack`, `cmd/runtime`, `cmd/cli`, `cmd/setup`), but the Dockerfile's build path still pointed at the now-deleted `cmd/server`.

## Symptom
Any docker build — Fly deploy, the README's "Option B: Manual deploy" flow, the `make build` Docker path — fails with:
\`\`\`
go: package github.com/bryanneva/ponko/cmd/server: no Go files in /app/cmd/server
\`\`\`

## Fix
One-line change: `./cmd/server` → `./cmd/slack`. The Slack bot is the canonical deployment target for the OSS distribution, so the binary keeps its existing name (`server`) and the ENTRYPOINT is unchanged.

A follow-up could parameterize this with a Docker build arg (`TARGET=slack|runtime|cli`) so the same Dockerfile can ship any of the binaries, but that's a bigger change — keeping this minimal so the deploy path is unblocked.

## Discovered while
Provisioning ponko-bn for [Consolidation M2](https://github.com/bryanneva/ponko-planning/blob/main/projects/active/consolidation.md). Without this, `fly deploy --app ponko-bn` fails before reaching any of the actual cutover work.

## Test plan
- [x] \`docker build\` succeeds locally (tested with the Fly remote builder during this session)
- [ ] CI green