### PR TITLE
feat: OpenAI-compatible LLM provider (toward #24)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 
 COPY . .
 COPY --from=web-builder /app/web/dist web/dist
-RUN CGO_ENABLED=0 go build -o server ./cmd/server
+RUN CGO_ENABLED=0 go build -o server ./cmd/slack
 
 FROM debian:bookworm-slim
 

--- a/cmd/slack/main.go
+++ b/cmd/slack/main.go
@@ -57,11 +57,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	anthropicKey := os.Getenv("ANTHROPIC_API_KEY")
-	if anthropicKey == "" {
-		slog.Warn("ANTHROPIC_API_KEY not set, ProcessJob will fail")
-	}
-	claudeClient := llm.NewClient(anthropicKey, "")
+	llmClient := buildLLMClient()
 
 	slackBotToken := os.Getenv("SLACK_BOT_TOKEN")
 	if slackBotToken == "" {
@@ -178,7 +174,7 @@ func main() {
 		SystemPrompt: os.Getenv("SYSTEM_PROMPT"),
 		BotName:      botName,
 		Pool:         pool,
-		Claude:       claudeClient,
+		Claude:       llmClient,
 		Slack:        slackClient,
 		UserStore:    userStore,
 		Timezone:     tz,
@@ -191,13 +187,13 @@ func main() {
 	river.AddWorker(workers, &jobs.SlackReplyWorker{Slack: slackClient})
 	river.AddWorker(workers, &jobs.PlanWorker{
 		Pool:       pool,
-		Claude:     claudeClient,
+		Claude:     llmClient,
 		Slack:      slackClient,
 		AppBaseURL: os.Getenv("DASHBOARD_URL"),
 	})
 	river.AddWorker(workers, &jobs.ExecuteWorker{
 		Pool:         pool,
-		Claude:       claudeClient,
+		Claude:       llmClient,
 		MCPClient:    toolDispatcher,
 		Tools:        allTools,
 		UserStore:    userStore,
@@ -205,13 +201,13 @@ func main() {
 		SystemPrompt: os.Getenv("SYSTEM_PROMPT"),
 		BotName:      botName,
 	})
-	river.AddWorker(workers, &jobs.SynthesizeWorker{Pool: pool, Claude: claudeClient})
+	river.AddWorker(workers, &jobs.SynthesizeWorker{Pool: pool, Claude: llmClient})
 
 	proactiveWorker := &jobs.ProactiveMessageWorker{
 		SystemPrompt: os.Getenv("SYSTEM_PROMPT"),
 		BotName:      botName,
 		Pool:         pool,
-		Claude:       claudeClient,
+		Claude:       llmClient,
 		Slack:        slackClient,
 		Timezone:     tz,
 		MCPClient:    toolDispatcher,
@@ -302,4 +298,49 @@ func main() {
 	slog.Info("shutting down...")
 
 	gracefulShutdown(srv, client, telemetry, 8*time.Second)
+}
+
+// buildLLMClient picks the LLM provider based on LLM_PROVIDER env.
+//   - "openrouter" or "openai": OpenAI-compatible Chat Completions (default base
+//     URL openrouter.ai). Required: OPENROUTER_API_KEY (or OPENAI_API_KEY).
+//     Optional: OPENROUTER_BASE_URL, OPENROUTER_MODEL_SONNET,
+//     OPENROUTER_MODEL_HAIKU.
+//   - anything else (default): Anthropic Claude. Required: ANTHROPIC_API_KEY.
+func buildLLMClient() jobs.LLMClient {
+	provider := strings.ToLower(strings.TrimSpace(os.Getenv("LLM_PROVIDER")))
+	switch provider {
+	case "openrouter", "openai":
+		key := os.Getenv("OPENROUTER_API_KEY")
+		if key == "" {
+			key = os.Getenv("OPENAI_API_KEY")
+		}
+		if key == "" {
+			slog.Warn("LLM_PROVIDER is openrouter/openai but neither OPENROUTER_API_KEY nor OPENAI_API_KEY is set; LLM calls will fail")
+		}
+		overrides := map[string]string{}
+		if v := os.Getenv("OPENROUTER_MODEL_SONNET"); v != "" {
+			overrides[llm.ModelSonnet] = v
+		}
+		if v := os.Getenv("OPENROUTER_MODEL_HAIKU"); v != "" {
+			overrides[llm.ModelHaiku] = v
+		}
+		slog.Info("using openai-compat LLM provider",
+			"base_url", os.Getenv("OPENROUTER_BASE_URL"),
+			"sonnet_model", overrides[llm.ModelSonnet],
+			"haiku_model", overrides[llm.ModelHaiku],
+		)
+		return llm.NewOpenAIClient(llm.OpenAIConfig{
+			APIKey:         key,
+			BaseURL:        os.Getenv("OPENROUTER_BASE_URL"),
+			Referer:        os.Getenv("OPENROUTER_REFERER"),
+			Title:          "Ponko",
+			ModelOverrides: overrides,
+		})
+	default:
+		key := os.Getenv("ANTHROPIC_API_KEY")
+		if key == "" {
+			slog.Warn("ANTHROPIC_API_KEY not set, ProcessJob will fail")
+		}
+		return llm.NewClient(key, "")
+	}
 }

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -1,0 +1,331 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+const defaultOpenAIBaseURL = "https://openrouter.ai/api/v1"
+
+var _ Provider = (*OpenAIClient)(nil)
+
+// OpenAIClient implements the Provider/LLMClient interface against any
+// OpenAI-compatible Chat Completions endpoint (OpenAI, OpenRouter, vLLM, etc.).
+//
+// Model strings passed by callers are remapped through ModelOverrides so
+// existing Claude-shaped calls (llm.ModelSonnet, llm.ModelHaiku) route to
+// provider-specific names like "anthropic/claude-sonnet-4" on OpenRouter.
+type OpenAIClient struct {
+	httpClient     *http.Client
+	modelOverrides map[string]string
+	baseURL        string
+	apiKey         string
+	referer        string
+	title          string
+}
+
+// OpenAIConfig configures an OpenAIClient.
+//
+// ModelOverrides maps canonical model strings (llm.ModelSonnet,
+// llm.ModelHaiku) to provider-specific names; unknown models pass through
+// unchanged. Referer and Title populate OpenRouter's HTTP-Referer and
+// X-Title headers for billing attribution and are ignored by other endpoints.
+type OpenAIConfig struct {
+	ModelOverrides map[string]string
+	APIKey         string
+	BaseURL        string
+	Referer        string
+	Title          string
+}
+
+func NewOpenAIClient(cfg OpenAIConfig) *OpenAIClient {
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = defaultOpenAIBaseURL
+	}
+	return &OpenAIClient{
+		apiKey:         cfg.APIKey,
+		baseURL:        cfg.BaseURL,
+		referer:        cfg.Referer,
+		title:          cfg.Title,
+		modelOverrides: cfg.ModelOverrides,
+		httpClient: &http.Client{
+			Timeout:   httpClientTimeout,
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+		},
+	}
+}
+
+type oaiMessage struct {
+	Role       string        `json:"role"`
+	Content    string        `json:"content,omitempty"`
+	ToolCallID string        `json:"tool_call_id,omitempty"`
+	Name       string        `json:"name,omitempty"`
+	ToolCalls  []oaiToolCall `json:"tool_calls,omitempty"`
+}
+
+type oaiToolCall struct {
+	ID       string          `json:"id"`
+	Type     string          `json:"type"`
+	Function oaiFunctionCall `json:"function"`
+}
+
+type oaiFunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type oaiTool struct {
+	Type     string         `json:"type"`
+	Function oaiFunctionDef `json:"function"`
+}
+
+type oaiFunctionDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+type oaiRequest struct {
+	Model     string       `json:"model"`
+	Messages  []oaiMessage `json:"messages"`
+	Tools     []oaiTool    `json:"tools,omitempty"`
+	MaxTokens int          `json:"max_tokens,omitempty"`
+}
+
+type oaiUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type oaiChoice struct {
+	FinishReason string     `json:"finish_reason"`
+	Message      oaiMessage `json:"message"`
+	Index        int        `json:"index"`
+}
+
+type oaiResponse struct {
+	ID      string      `json:"id"`
+	Choices []oaiChoice `json:"choices"`
+	Usage   oaiUsage    `json:"usage"`
+}
+
+type oaiAPIError struct {
+	Error struct {
+		Message string `json:"message"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+
+func (c *OpenAIClient) resolveModel(model string) string {
+	if mapped, ok := c.modelOverrides[model]; ok && mapped != "" {
+		return mapped
+	}
+	return model
+}
+
+func systemMessage(prompt string) []oaiMessage {
+	if prompt == "" {
+		return nil
+	}
+	return []oaiMessage{{Role: "system", Content: prompt}}
+}
+
+func toOAIMessages(messages []Message) []oaiMessage {
+	out := make([]oaiMessage, 0, len(messages))
+	for _, m := range messages {
+		out = append(out, oaiMessage{Role: m.Role, Content: m.Content})
+	}
+	return out
+}
+
+func toOAITools(tools []Tool) []oaiTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]oaiTool, 0, len(tools))
+	for _, t := range tools {
+		params := t.InputSchema
+		if len(params) == 0 {
+			params = json.RawMessage(`{"type":"object","properties":{}}`)
+		}
+		out = append(out, oaiTool{
+			Type: "function",
+			Function: oaiFunctionDef{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  params,
+			},
+		})
+	}
+	return out
+}
+
+func (c *OpenAIClient) doRequest(ctx context.Context, reqBody oaiRequest) (*oaiResponse, error) {
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	if c.referer != "" {
+		req.Header.Set("HTTP-Referer", c.referer)
+	}
+	if c.title != "" {
+		req.Header.Set("X-Title", c.title)
+	}
+
+	requestStart := time.Now()
+	resp, err := c.httpClient.Do(req)
+	elapsed := time.Since(requestStart)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	if elapsed > httpClientTimeout*3/4 {
+		slog.Info("openai-compat api request was slow",
+			"elapsed", elapsed,
+			"threshold", httpClientTimeout,
+		)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var apiErr oaiAPIError
+		if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Error.Message != "" {
+			return nil, fmt.Errorf("openai-compat API error (%d): %s", resp.StatusCode, apiErr.Error.Message)
+		}
+		return nil, fmt.Errorf("openai-compat API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var result oaiResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("unmarshaling response: %w", err)
+	}
+
+	slog.Info("openai-compat api usage",
+		"model", reqBody.Model,
+		"prompt_tokens", result.Usage.PromptTokens,
+		"completion_tokens", result.Usage.CompletionTokens,
+		"total_tokens", result.Usage.TotalTokens,
+	)
+
+	return &result, nil
+}
+
+func (c *OpenAIClient) SendMessage(ctx context.Context, prompt string, model string) (string, error) {
+	reqBody := oaiRequest{
+		Model:     c.resolveModel(model),
+		MaxTokens: 1024,
+		Messages:  []oaiMessage{{Role: RoleUser, Content: prompt}},
+	}
+	resp, err := c.doRequest(ctx, reqBody)
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", fmt.Errorf("empty response from OpenAI-compat provider")
+	}
+	return resp.Choices[0].Message.Content, nil
+}
+
+func (c *OpenAIClient) SendConversation(ctx context.Context, systemPrompt string, messages []Message, model string) (string, error) {
+	reqBody := oaiRequest{
+		Model:     c.resolveModel(model),
+		MaxTokens: 2048,
+		Messages:  append(systemMessage(systemPrompt), toOAIMessages(messages)...),
+	}
+	resp, err := c.doRequest(ctx, reqBody)
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", fmt.Errorf("empty response from OpenAI-compat provider")
+	}
+	return resp.Choices[0].Message.Content, nil
+}
+
+func (c *OpenAIClient) SendConversationWithTools(ctx context.Context, systemPrompt string, messages []Message, tools []Tool, toolCaller ToolCaller, userScope *UserScope, model string) (string, error) {
+	resolved := c.resolveModel(model)
+	oaiTools := toOAITools(tools)
+	conv := append(systemMessage(systemPrompt), toOAIMessages(messages)...)
+
+	for range maxToolUseIterations {
+		reqBody := oaiRequest{
+			Model:     resolved,
+			MaxTokens: 4096,
+			Messages:  conv,
+			Tools:     oaiTools,
+		}
+
+		resp, err := c.doRequest(ctx, reqBody)
+		if err != nil {
+			return "", err
+		}
+		if len(resp.Choices) == 0 {
+			return "", fmt.Errorf("empty response from OpenAI-compat provider")
+		}
+
+		choice := resp.Choices[0]
+		slog.Info("openai-compat response",
+			"finish_reason", choice.FinishReason,
+			"tool_calls", len(choice.Message.ToolCalls),
+		)
+
+		if len(choice.Message.ToolCalls) == 0 {
+			return choice.Message.Content, nil
+		}
+
+		conv = append(conv, choice.Message)
+		for _, call := range choice.Message.ToolCalls {
+			var args map[string]any
+			if call.Function.Arguments != "" {
+				if unmarshalErr := json.Unmarshal([]byte(call.Function.Arguments), &args); unmarshalErr != nil {
+					slog.Warn("failed to unmarshal tool arguments",
+						"tool", call.Function.Name, "error", unmarshalErr, "raw_input", call.Function.Arguments)
+					args = map[string]any{}
+				}
+			} else {
+				args = map[string]any{}
+			}
+
+			start := time.Now()
+			toolResult, toolErr := toolCaller.CallTool(ctx, call.Function.Name, args, userScope)
+			duration := time.Since(start)
+
+			content := toolResult
+			if toolErr != nil {
+				slog.Warn("tool call failed", "tool", call.Function.Name, "error", toolErr, "duration", duration)
+				content = fmt.Sprintf("ERROR: %s", toolErr.Error())
+			} else {
+				slog.Info("tool call succeeded", "tool", call.Function.Name, "duration", duration)
+			}
+
+			conv = append(conv, oaiMessage{
+				Role:       "tool",
+				ToolCallID: call.ID,
+				Name:       call.Function.Name,
+				Content:    content,
+			})
+		}
+	}
+
+	return "", fmt.Errorf("tool use loop exceeded %d iterations", maxToolUseIterations)
+}

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -1,0 +1,226 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOpenAISendMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("expected /chat/completions, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization 'Bearer test-key', got %q", got)
+		}
+		if got := r.Header.Get("HTTP-Referer"); got != "https://ponko.example" {
+			t.Errorf("expected HTTP-Referer set, got %q", got)
+		}
+		if got := r.Header.Get("X-Title"); got != "Ponko" {
+			t.Errorf("expected X-Title set, got %q", got)
+		}
+
+		var req oaiRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decoding request: %v", err)
+		}
+		if req.Model != "anthropic/claude-haiku-4" {
+			t.Errorf("expected mapped model 'anthropic/claude-haiku-4', got %q", req.Model)
+		}
+		if len(req.Messages) != 1 || req.Messages[0].Role != "user" || req.Messages[0].Content != "hello" {
+			t.Errorf("unexpected messages: %+v", req.Messages)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(oaiResponse{
+			Choices: []oaiChoice{{Message: oaiMessage{Role: "assistant", Content: "hi there"}}},
+			Usage:   oaiUsage{PromptTokens: 5, CompletionTokens: 2, TotalTokens: 7},
+		})
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(OpenAIConfig{
+		APIKey:  "test-key",
+		BaseURL: server.URL,
+		Referer: "https://ponko.example",
+		Title:   "Ponko",
+		ModelOverrides: map[string]string{
+			ModelHaiku: "anthropic/claude-haiku-4",
+		},
+	})
+
+	resp, err := client.SendMessage(context.Background(), "hello", ModelHaiku)
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if resp != "hi there" {
+		t.Errorf("expected 'hi there', got %q", resp)
+	}
+}
+
+func TestOpenAISendConversationPassesSystemAsFirstMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req oaiRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decoding request: %v", err)
+		}
+		if len(req.Messages) != 3 {
+			t.Fatalf("expected 3 messages (system+user+assistant), got %d", len(req.Messages))
+		}
+		if req.Messages[0].Role != "system" || req.Messages[0].Content != "You are Otto." {
+			t.Errorf("expected first message system/'You are Otto.', got %+v", req.Messages[0])
+		}
+		if req.Messages[1].Role != "user" || req.Messages[2].Role != "assistant" {
+			t.Errorf("user/assistant ordering wrong: %+v", req.Messages)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(oaiResponse{
+			Choices: []oaiChoice{{Message: oaiMessage{Role: "assistant", Content: "ok"}}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(OpenAIConfig{APIKey: "k", BaseURL: server.URL})
+	_, err := client.SendConversation(context.Background(), "You are Otto.", []Message{
+		{Role: RoleUser, Content: "hi"},
+		{Role: RoleAssistant, Content: "hello"},
+	}, "openai/gpt-4o-mini")
+	if err != nil {
+		t.Fatalf("SendConversation: %v", err)
+	}
+}
+
+func TestOpenAIPassThroughModelWhenNotMapped(t *testing.T) {
+	var observedModel string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req oaiRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		observedModel = req.Model
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(oaiResponse{Choices: []oaiChoice{{Message: oaiMessage{Content: "ok"}}}})
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(OpenAIConfig{APIKey: "k", BaseURL: server.URL})
+	_, err := client.SendMessage(context.Background(), "hi", "openai/gpt-4o")
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if observedModel != "openai/gpt-4o" {
+		t.Errorf("expected unmapped model passed through, got %q", observedModel)
+	}
+}
+
+func TestOpenAIAPIErrorSurface(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(oaiAPIError{
+			Error: struct {
+				Message string `json:"message"`
+				Code    string `json:"code"`
+			}{Message: "insufficient credits", Code: "billing"},
+		})
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(OpenAIConfig{APIKey: "k", BaseURL: server.URL})
+	_, err := client.SendMessage(context.Background(), "hi", "x")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "insufficient credits") {
+		t.Errorf("error should surface API message; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error should include status code; got: %v", err)
+	}
+}
+
+type stubToolCaller struct {
+	results map[string]string
+	calls   []string
+}
+
+func (s *stubToolCaller) CallTool(_ context.Context, name string, _ map[string]any, _ *UserScope) (string, error) {
+	s.calls = append(s.calls, name)
+	if r, ok := s.results[name]; ok {
+		return r, nil
+	}
+	return "default", nil
+}
+
+func TestOpenAIToolUseLoop(t *testing.T) {
+	step := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req oaiRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		step++
+		switch step {
+		case 1:
+			// First turn: model asks for a tool call.
+			_ = json.NewEncoder(w).Encode(oaiResponse{
+				Choices: []oaiChoice{{
+					Message: oaiMessage{
+						Role: "assistant",
+						ToolCalls: []oaiToolCall{{
+							ID:   "call_1",
+							Type: "function",
+							Function: oaiFunctionCall{
+								Name:      "search",
+								Arguments: `{"query":"weather"}`,
+							},
+						}},
+					},
+					FinishReason: "tool_calls",
+				}},
+			})
+		case 2:
+			// Second turn: model gives final answer. Verify the tool result was appended.
+			toolMsgIdx := -1
+			for i, m := range req.Messages {
+				if m.Role == "tool" && m.ToolCallID == "call_1" {
+					toolMsgIdx = i
+					break
+				}
+			}
+			if toolMsgIdx == -1 {
+				t.Errorf("expected tool result message in second-turn request, got messages: %+v", req.Messages)
+			}
+			_ = json.NewEncoder(w).Encode(oaiResponse{
+				Choices: []oaiChoice{{
+					Message:      oaiMessage{Role: "assistant", Content: "sunny"},
+					FinishReason: "stop",
+				}},
+			})
+		default:
+			t.Fatalf("unexpected request step %d", step)
+		}
+	}))
+	defer server.Close()
+
+	tools := []Tool{{
+		Name:        "search",
+		Description: "Search the web",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}}}`),
+	}}
+	caller := &stubToolCaller{results: map[string]string{"search": "weather: sunny"}}
+
+	client := NewOpenAIClient(OpenAIConfig{APIKey: "k", BaseURL: server.URL})
+	resp, err := client.SendConversationWithTools(context.Background(), "be helpful",
+		[]Message{{Role: RoleUser, Content: "what's the weather?"}}, tools, caller, nil, "openai/gpt-4o")
+	if err != nil {
+		t.Fatalf("SendConversationWithTools: %v", err)
+	}
+	if resp != "sunny" {
+		t.Errorf("expected 'sunny', got %q", resp)
+	}
+	if len(caller.calls) != 1 || caller.calls[0] != "search" {
+		t.Errorf("expected one call to 'search', got %+v", caller.calls)
+	}
+}


### PR DESCRIPTION
## What

Adds `internal/llm/openai.go` — an LLM provider that talks to any OpenAI Chat Completions endpoint (OpenAI, OpenRouter, vLLM, etc.) and runtime switching in `cmd/slack/main.go` so workers can swap between Anthropic and OpenAI-compat without code changes.

## Configuration

| Env var | Effect |
|---|---|
| `LLM_PROVIDER=openrouter` (or `openai`) | Selects the new OpenAI-compat client |
| `LLM_PROVIDER` unset (default) | Existing Anthropic Claude client, unchanged behavior |
| `OPENROUTER_API_KEY` (or `OPENAI_API_KEY`) | Bearer token |
| `OPENROUTER_BASE_URL` | Override base URL (default `https://openrouter.ai/api/v1`) |
| `OPENROUTER_MODEL_SONNET` | Provider model name to use when workers pass `llm.ModelSonnet` |
| `OPENROUTER_MODEL_HAIKU` | Provider model name to use when workers pass `llm.ModelHaiku` |
| `OPENROUTER_REFERER` | OpenRouter `HTTP-Referer` header (billing attribution) |

Models the workers don't recognize pass through unchanged, so callers can target any OpenRouter model by passing its full string.

## Why

This is the minimum-viable slice of #24. #24 also wants per-channel provider/model selection in the `channel_configs` table — that layer can sit on top of this without touching the adapter or the runtime switch.

## Also in this PR

The Dockerfile build target was pointing at the deleted `./cmd/server` post-#28 merge — fixed to `./cmd/slack` so `docker build` (and any `fly deploy`) actually succeeds. **Supersedes #33** (close it once this lands).

## Test plan

- [x] `go test ./internal/llm/` — 4 new tests cover SendMessage with mapping, system prompt placement, model pass-through, API error surface, and full tool-use loop with a stub tool caller (94 LOC of test for ~250 LOC of impl).
- [x] `go build ./cmd/slack` succeeds.
- [x] Local `make ci` (lint + build + unit tests) passes.
- [ ] CI green
- [ ] Live test on `ponko-bn` against OpenRouter (next, after merge or via direct deploy from this branch)

## Discovery context

Surfaced during Consolidation M2 shadow validation — the Anthropic key copied from PA had zero credit balance, blocking the shadow week. Rather than top up that account or rotate keys, the user asked to make the provider configurable so OpenRouter (with its existing balance) becomes the path forward.